### PR TITLE
Migrating PHPUnit setting and using assertSame

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -8,15 +9,16 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Exchange Rates Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/tests/Unit/ConvertBetweenDateRangeTest.php
+++ b/tests/Unit/ConvertBetweenDateRangeTest.php
@@ -25,7 +25,7 @@ class ConvertBetweenDateRangeTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForSingleCurrencyPair());
 
-        self::assertEquals(
+        self::assertSame(
             $this->expectedForSingleCurrencyPair(),
             (new ExchangeRate($requestBuilderMock))->convertBetweenDateRange(
                 100,
@@ -52,7 +52,7 @@ class ConvertBetweenDateRangeTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForMultipleCurrencies());
 
-        self::assertEquals(
+        self::assertSame(
             $this->expectedForMultipleCurrencies(),
             (new ExchangeRate($requestBuilderMock))->convertBetweenDateRange(
                 100,

--- a/tests/Unit/ConvertTest.php
+++ b/tests/Unit/ConvertTest.php
@@ -23,7 +23,7 @@ class ConvertTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForTodayForSingleCurrency());
 
-        self::assertEquals(
+        self::assertSame(
             '118.68640000',
             (new ExchangeRate($requestBuilderMock))->convert(100, 'GBP', 'EUR'),
         );
@@ -42,7 +42,7 @@ class ConvertTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForTodayForMultipleCurrencies());
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'EUR' => '118.68640000',
                 'USD' => '137.63950000',
@@ -64,7 +64,7 @@ class ConvertTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForYesterdayForSingleCurrency());
 
-        self::assertEquals(
+        self::assertSame(
             '118.61760000',
             (new ExchangeRate($requestBuilderMock))->convert(100, 'GBP', 'EUR', Carbon::create(2021, 10, 25)),
         );
@@ -83,7 +83,7 @@ class ConvertTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForYesterdayForMultipleCurrencies());
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'EUR' => '118.61760000',
                 'USD' => '137.73040000',

--- a/tests/Unit/CurrenciesTest.php
+++ b/tests/Unit/CurrenciesTest.php
@@ -18,7 +18,7 @@ class CurrenciesTest extends TestCase
             ->once()
             ->andReturn($this->mockResponse());
 
-        self::assertEquals(
+        self::assertSame(
             $this->expectedResponse(),
             (new ExchangeRate($requestBuilderMock))->currencies(),
         );

--- a/tests/Unit/ExchangeRateTest.php
+++ b/tests/Unit/ExchangeRateTest.php
@@ -23,7 +23,7 @@ class ExchangeRateTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForTodayForSingleCurrency());
 
-        self::assertEquals(
+        self::assertSame(
             '1.186864',
             (new ExchangeRate($requestBuilderMock))->exchangeRate('GBP', 'EUR'),
         );
@@ -42,7 +42,7 @@ class ExchangeRateTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForTodayForMultipleCurrencies());
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'EUR' => '1.186864',
                 'USD' => '1.376395',
@@ -64,7 +64,7 @@ class ExchangeRateTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForYesterdayForSingleCurrency());
 
-        self::assertEquals(
+        self::assertSame(
             '1.186176',
             (new ExchangeRate($requestBuilderMock))->exchangeRate('GBP', 'EUR', Carbon::create(2021, 10, 25)),
         );
@@ -83,7 +83,7 @@ class ExchangeRateTest extends TestCase
             ]])
             ->andReturn($this->mockResponseForYesterdayForMultipleCurrencies());
 
-        self::assertEquals(
+        self::assertSame(
             [
                 'EUR' => '1.186176',
                 'USD' => '1.377304',


### PR DESCRIPTION
# Changed log

- Since this PHP package supports `PHPUnit 9` version, it can be good to migrate PHPUnit setting to new format.
- Using the `assertSame` to make assertion equals strict.